### PR TITLE
fix: use mm provider as default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,9 @@
   "files.autoSave": "onFocusChange",
   "prettier.requireConfig": false,
   "prettier.semi": false,
-  "editor.codeActionsOnSave": { "source.fixAll": true },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,

--- a/packages/dapp/components/lib/hooks/contracts/useManagerManaged.tsx
+++ b/packages/dapp/components/lib/hooks/contracts/useManagerManaged.tsx
@@ -27,6 +27,7 @@ export const ManagedContractsContext = createContext<ManagedContracts>(null);
 
 export const ManagedContractsContextProvider: React.FC<ChildrenShim> = ({ children }) => {
   const [{ provider }] = useWeb3();
+
   const deployedContracts = useDeployedContracts();
   const [managedContracts, setManagedContracts] = useState<ManagedContracts>(null);
 

--- a/packages/dapp/components/lib/hooks/useWeb3.tsx
+++ b/packages/dapp/components/lib/hooks/useWeb3.tsx
@@ -1,4 +1,4 @@
-import { JsonRpcProvider, JsonRpcSigner, Web3Provider } from "@ethersproject/providers";
+import { JsonRpcProvider, JsonRpcSigner, Web3Provider, WebSocketProvider } from "@ethersproject/providers";
 import { useAccount, useProvider, useSigner } from "wagmi";
 import { WagmiConfig, createClient, chain } from "wagmi";
 import { ConnectKitProvider, getDefaultClient } from "connectkit";
@@ -47,7 +47,17 @@ export const UseWeb3Provider: FC<ChildrenShim> = ({ children }) => {
 };
 
 const useWeb3 = (): [Web3State] => {
-  const provider = useProvider();
+  let provider: PossibleProviders = null;
+  if (typeof window !== "undefined") {
+    if (window.ethereum) {
+      provider = new Web3Provider(window.ethereum);
+    } else if (IS_DEV) {
+      provider = new JsonRpcProvider(LOCAL_NODE_ADDRESS);
+    } else {
+      provider = new WebSocketProvider("wss://ethereum-rpc.publicnode.com", 1);
+    }
+  }
+
   const { isConnecting, address } = useAccount();
   const { data: signer } = useSigner();
 


### PR DESCRIPTION
Resolves https://github.com/pavlovcik/uad.ubq.fi/issues/1

- The issue stemmed from the fact a fallback provider was being used and it failed to reach quorum on occasion. Removed the fallback which was solved to solve single point of failure by providing multiple endpoints lmao but `/credits` also requires a connected wallet and markets are just ext links

- staking isn't displayed until the wallet is connected so it makes sense to just use the MM provider
- development needs will be forking mainnet likely although if not set the provider to localhost
- otherwise use a websocket connection

QA:
- I've spammed refresh and it won't reproduce
- Been think of how I can test it with cypress but that would need some type of UI handling if the provider(s) fail
- would benefit from `rpc-racer`

